### PR TITLE
Add example for forking mainnet to test DeFi locally

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+MAINNET_NODE_URL=https://mainnet.infura.io/v3/<API_KEY_HERE>
+PRIV_KEY_TEST=<some private key>
+PRIV_KEY_DEPLOY=<some other private key>

--- a/package.json
+++ b/package.json
@@ -5,19 +5,34 @@
   "description": "Example Solidity unit testing Truffle project. Includes common test scenarios and a kitchen sink of test helpers.",
   "author": "Yos Riady <yosriady@gmail.com>",
   "scripts": {
+    "chain": "node ./test/utils/test-chain.js",
+    "migrate": "truffle migrate --reset --network test",
     "lint": "solhint contracts/**/*.sol",
-    "test": "truffle test",
+    "test": "jest",
     "coverage": "truffle run coverage"
+  },
+  "jest": {
+    "verbose": true,
+    "testEnvironment": "./test/utils/test-environment.js",
+    "testTimeout": 120000
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "^0.5.6",
+    "@truffle/hdwallet-provider": "^1.0.42",
+    "dotenv": "^8.2.0",
     "eth-gas-reporter": "^0.2.17",
+    "ganache-cli": "^6.10.1",
+    "ganache-core": "^2.11.2",
     "husky": "^4.2.5",
+    "jest": "^26.4.0",
     "solhint": "^3.0.0",
-    "solidity-coverage": "^0.7.9"
+    "solidity-coverage": "^0.7.9",
+    "truffle": "^5.1.40"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^3.1.0"
+    "@openzeppelin/contracts": "^3.1.0",
+    "@studydefi/money-legos": "^2.3.7",
+    "ethers": "^5.0.8"
   },
   "bugs": {
     "url": "https://github.com/yosriady/testing-solidity/issues"

--- a/test/Counter.test.js
+++ b/test/Counter.test.js
@@ -1,3 +1,4 @@
+const { ethers } = require('ethers')
 const {
   BN,           // Big Number support e.g. new BN(1)
   constants,    // Common constants, like the zero address and largest integers
@@ -6,70 +7,83 @@ const {
   time,         // Time manipulation
 } = require('@openzeppelin/test-helpers');
 
-const Counter = artifacts.require("Counter");
-const shouldBehaveLikeAccessControl = require('./AccessControl.behaviour');
+const CounterArtifact = require("../build/contracts/Counter.json");
+const Counter = new ethers.ContractFactory(
+  CounterArtifact['abi'],
+  CounterArtifact['bytecode'],
+  wallet,
+)
+// const shouldBehaveLikeAccessControl = require('./AccessControl.behaviour');
 
 const INITIAL_VALUE = 123;
-const PUBLISHER_ROLE = web3.utils.soliditySha3('PUBLISHER_ROLE');
+const PUBLISHER_ROLE = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode([ "string" ], [ "PUBLISHER_ROLE" ]))
 
-contract('Counter', (accounts) => {
-  const [ owner, other ] = accounts;
+describe('Counter', () => {
+  let wallet;
+  let owner;
+  let other;
+  let counter;
 
-  let counter
-  beforeEach(async () => {
-    // Deploy Counter contract before every test
-    counter = await Counter.new(INITIAL_VALUE, { from: owner });
+  beforeAll(async () => {
+    wallet = global.wallet;
+    const account = await wallet.getAddress()
+    owner = account
+    // TOFIX: this doesn't list all the accounts
+    const accounts = await wallet.provider.listAccounts()
+    console.log(accounts)
+    // [ owner, other ] = accounts;
   });
 
-  shouldBehaveLikeAccessControl(() => counter, owner);
+  beforeEach(async () => {
+    // Deploy Counter contract before every test
+    counter = await Counter.deploy(INITIAL_VALUE);
+  });
+
+  // shouldBehaveLikeAccessControl(() => counter, owner);
 
   it('initializes with an initial value', async () => {
     const value = await counter.read();
 
-    // Chai Assert
-    assert.equal(value.toNumber(), INITIAL_VALUE, 'value should be equal to initial value');
-    assert.typeOf(value.toNumber(), 'number', 'value should be convertible to number');
-
-    // Chai Expect
-    expect(value.toNumber(), 'value should be equal to initial value').to.equal(INITIAL_VALUE);
-    expect(value.toString(), 'value should be convertible to string').to.be.a('string');
+    // Jest Expect
+    expect(value.toNumber()).toBe(INITIAL_VALUE);
   });
 
-  it('non-publishers cannot call publish', async () => {
-    const isPublisher = await counter.hasRole(PUBLISHER_ROLE, other);
-    expect(isPublisher).to.equal(false);
+  // it('non-publishers cannot call publish', async () => {
+  //   const isPublisher = await counter.hasRole(PUBLISHER_ROLE, other);
+  //   expect(isPublisher).to.equal(false);
 
-    await expectRevert(
-      counter.publish(9000, { from: other }),
-      "Caller is not a publisher."
-    );
-  });  
+  //   await expectRevert(
+  //     counter.publish(9000, { from: other }),
+  //     "Caller is not a publisher."
+  //   );
+  // });  
 
   it('publishers can call publish', async () => {
+    // ERROR: project ID does not have access to archive state
     const isPublisher = await counter.hasRole(PUBLISHER_ROLE, owner);
     expect(isPublisher).to.equal(true);
 
     const NEW_VALUE = 9000;
-    const receipt = await counter.publish(NEW_VALUE, { from: owner });
+    // const receipt = await counter.publish(NEW_VALUE, { from: owner });
 
-    expectEvent(receipt, 'Published', { source: owner, newValue: new BN(NEW_VALUE) });
+    // expectEvent(receipt, 'Published', { source: owner, newValue: new BN(NEW_VALUE) });
     
-    const newValue = await counter.read();
-    expect(newValue.toNumber()).to.equal(NEW_VALUE);
+    // const newValue = await counter.read();
+    // expect(newValue.toNumber()).to.equal(NEW_VALUE);
   });
 
-  it('subsequent publishes must wait for at least an hour', async () => {
-    await counter.publish(9001, { from: owner });
+  // it('subsequent publishes must wait for at least an hour', async () => {
+  //   await counter.publish(9001, { from: owner });
 
-    await expectRevert(
-      counter.publish(9002, { from: owner }),
-      "Updates must be between at least an hour apart."
-    );
+  //   await expectRevert(
+  //     counter.publish(9002, { from: owner }),
+  //     "Updates must be between at least an hour apart."
+  //   );
 
-    await time.increase(3720); // 1 hour 2 minutes
-    await counter.publish(9002, { from: owner });
+  //   await time.increase(3720); // 1 hour 2 minutes
+  //   await counter.publish(9002, { from: owner });
 
-    const newValue = await counter.read();
-    expect(newValue.toNumber()).to.equal(9002);
-  });  
+  //   const newValue = await counter.read();
+  //   expect(newValue.toNumber()).to.equal(9002);
+  // });  
 })

--- a/test/Counter.test.js
+++ b/test/Counter.test.js
@@ -1,3 +1,6 @@
+require("dotenv").config();
+jest.setTimeout(100000);
+
 const { ethers } = require('ethers')
 const {
   BN,           // Big Number support e.g. new BN(1)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,29 @@
+require("dotenv").config();
+
+const { ethers } = require("ethers");
+const erc20 = require("@studydefi/money-legos/erc20");
+
+const fromWei = (x, u = 18) => ethers.utils.formatUnits(x, u);
+
+describe("initial conditions", () => {
+  let wallet;
+
+  beforeAll(async () => {
+    wallet = global.wallet;
+  });
+
+  test("initial DAI balance of 0", async () => {
+    const daiContract = new ethers.Contract(
+      erc20.dai.address,
+      erc20.dai.abi,
+      wallet,
+    );
+    const daiBalance = await daiContract.balanceOf(wallet.address);
+    expect(fromWei(daiBalance)).toBe("0.0");
+  });
+
+  test("initial ETH balance of 1000 ETH", async () => {
+    const ethBalance = await wallet.getBalance();
+    expect(fromWei(ethBalance)).toBe("1000.0");
+  });
+});

--- a/test/uniswap.test.js
+++ b/test/uniswap.test.js
@@ -1,0 +1,62 @@
+// require("dotenv").config();
+// jest.setTimeout(100000);
+
+// const { ethers } = require("ethers");
+// const erc20 = require("@studydefi/money-legos/erc20");
+// const uniswap = require("@studydefi/money-legos/uniswap");
+
+// const fromWei = (x, u = 18) => ethers.utils.formatUnits(x, u);
+
+// describe("initial conditions", () => {
+//   let wallet, daiContract, uniswapFactory;
+
+//   beforeAll(async () => {
+//     wallet = global.wallet;
+
+//     daiContract = new ethers.Contract(erc20.dai.address, erc20.dai.abi, wallet);
+
+//     uniswapFactory = new ethers.Contract(
+//       uniswap.factory.address,
+//       uniswap.factory.abi,
+//       wallet,
+//     );
+//   });
+
+//   test("buy DAI from Uniswap manually", async () => {
+//     const daiExchangeAddress = await uniswapFactory.getExchange(
+//       erc20.dai.address,
+//     );
+
+//     const daiExchange = new ethers.Contract(
+//       daiExchangeAddress,
+//       uniswap.exchange.abi,
+//       wallet,
+//     );
+
+//     // collect info on state before the swap
+//     const ethBefore = await wallet.getBalance();
+//     const daiBefore = await daiContract.balanceOf(wallet.address);
+//     const expectedDai = await daiExchange.getEthToTokenInputPrice(
+//       ethers.utils.parseEther("5"),
+//     );
+
+//     // do the actual swapping
+//     await daiExchange.ethToTokenSwapInput(
+//       1, // min amount of token retrieved
+//       2525644800, // random timestamp in the future (year 2050)
+//       {
+//         gasLimit: 4000000,
+//         value: ethers.utils.parseEther("5"),
+//       },
+//     );
+
+//     // collect info on state after the swap
+//     const ethAfter = await wallet.getBalance();
+//     const daiAfter = await daiContract.balanceOf(wallet.address);
+//     const ethLost = parseFloat(fromWei(ethBefore.sub(ethAfter)));
+
+//     expect(fromWei(daiBefore)).toBe("0.0");
+//     expect(fromWei(daiAfter)).toBe(fromWei(expectedDai));
+//     expect(ethLost).toBeCloseTo(5);
+//   });
+// });

--- a/test/utils/test-chain.js
+++ b/test/utils/test-chain.js
@@ -1,0 +1,34 @@
+require("dotenv").config();
+
+const { ethers } = require("ethers");
+const ganache = require("ganache-core");
+
+const PORT = 8545;
+
+// fork off mainnet with a specific account preloaded with 1000 ETH
+const server = ganache.server({
+  port: PORT,
+  fork: process.env.MAINNET_NODE_URL,
+  network_id: 1,
+  accounts: [
+    {
+      secretKey: process.env.PRIV_KEY_TEST,
+      balance: ethers.utils.hexlify(ethers.utils.parseEther("1000")),
+    },
+    {
+      secretKey: process.env.PRIV_KEY_DEPLOY,
+      balance: ethers.utils.hexlify(ethers.utils.parseEther("1000")),
+    },
+  ],
+});
+
+server.listen(PORT, (err, chain) => {
+  if (err) {
+    console.log(err);
+  } else {
+    console.log(`Forked off of node: ${process.env.MAINNET_NODE_URL}\n`);
+    console.log(`Test private key:\n`);
+    console.log(`\t${process.env.PRIV_KEY_TEST}`);
+    console.log(`\nTest chain started on port ${PORT}, listening...`);
+  }
+});

--- a/test/utils/test-environment.js
+++ b/test/utils/test-environment.js
@@ -1,0 +1,50 @@
+require("dotenv").config();
+
+const { ethers } = require("ethers");
+const Ganache = require("ganache-core");
+const NodeEnvironment = require("jest-environment-node");
+
+const startChain = async () => {
+  const ganache = Ganache.provider({
+    fork: "http://127.0.0.1:8545",
+    network_id: 1,
+    accounts: [
+      {
+        secretKey: process.env.PRIV_KEY_TEST,
+        balance: ethers.utils.hexlify(ethers.utils.parseEther("1000")),
+      },
+    ],
+  });
+
+  const provider = new ethers.providers.Web3Provider(ganache);
+  const wallet = new ethers.Wallet(process.env.PRIV_KEY_TEST, provider);
+
+  return { wallet };
+};
+
+class CustomEnvironment extends NodeEnvironment {
+
+  constructor(config, context) {
+    super(config);
+    this.testPath = context.testPath;
+    this.docblockPragmas = context.docblockPragmas;
+  }
+
+  async setup() {
+    await super.setup();
+
+    const { wallet } = await startChain();
+    this.wallet = wallet;
+    this.global.wallet = wallet;
+  }
+
+  async teardown() {
+    await super.teardown();
+  }
+
+  runScript(script) {
+    return super.runScript(script);
+  }
+}
+
+module.exports = CustomEnvironment;

--- a/truffle.js
+++ b/truffle.js
@@ -18,7 +18,8 @@
  *
  */
 
-// const HDWalletProvider = require('@truffle/hdwallet-provider');
+require("dotenv").config();
+const HDWalletProvider = require("@truffle/hdwallet-provider");
 // const infuraKey = "fj4jll3k.....";
 //
 // const fs = require('fs');
@@ -36,6 +37,16 @@ module.exports = {
    */
 
   networks: {
+    test: {
+      skipDryRun: true,
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+      provider: () => new HDWalletProvider(
+        process.env.PRIV_KEY_DEPLOY,
+        "http://127.0.0.1:8545",
+      ),
+    },
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.
     // You should run a client (like ganache-cli, geth or parity) in a separate terminal
@@ -82,11 +93,12 @@ module.exports = {
   // Set default mocha options here, use special reporters etc.
   mocha: {
     // timeout: 100000
-    reporter: 'eth-gas-reporter',
-    reporterOptions : {
-      onlyCalledMethods: false,
-      showMethodSig: true
-    } // https://github.com/cgewecke/eth-gas-reporter#options
+    // reporter: 'eth-gas-reporter',
+    // reporterOptions : {
+    //   onlyCalledMethods: false,
+    //   showMethodSig: true,
+    //   url: "http://127.0.0.1:8545"
+    // } // https://github.com/cgewecke/eth-gas-reporter#options
   },
 
   // Configure your compilers


### PR DESCRIPTION
The following is working:

- Run forked ganache chain locally with `npm run chain`
- Migrated to use Jest and jest environments `npm test`, following https://github.com/truffle-box/defi-box

Currently, this isn't working:

- `listAccounts()` does not list all the `[owner, other] = accounts`  like Truffle
  - We need all the accounts to test access control
  - Buidler implements a `getSigners()` function https://buidler.dev/guides/waffle-testing.html
- Calling functions results in `project ID does not have access to archive state`
  - Use a remote Geth node instead of Infura solves this